### PR TITLE
Handle non-uppercase tag names correctly.

### DIFF
--- a/lib/Music/Tag/FLAC.pm
+++ b/lib/Music/Tag/FLAC.pm
@@ -53,8 +53,8 @@ sub get_tag {
     my $self     = shift;
     if ( $self->flac ) {
 		while (my ($t, $v) = each %{$self->flac->tags}) {
-			if ((exists $tagmap{$t}) && (defined $v)) {
-				my $method = $tagmap{$t};
+			if ((exists $tagmap{uc $t}) && (defined $v)) {
+				my $method = $tagmap{uc $t};
 				$self->info->set_data($method,$v);
 			}
 		}


### PR DESCRIPTION
Some FLAC files -- even those produced by "reference libFLAC 1.3.0 20130526" as used by [fre:ac](http://www.freac.org/) program -- use "Artist" tag which was not recognized as all tags were expected to be in upper case.

Fix this by simply forcing the tags to be upper-case before looking them up.
